### PR TITLE
Improve decoder usability and implement io.WriteCloser for the encoder

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -1,0 +1,26 @@
+package rapidyenc
+
+/*
+#cgo noescape rapidyenc_version
+#cgo nocallback rapidyenc_version
+#cgo noescape rapidyenc_decode_init
+#cgo nocallback rapidyenc_decode_init
+#cgo noescape rapidyenc_decode_kernel
+#cgo nocallback rapidyenc_decode_kernel
+#cgo noescape rapidyenc_decode_incremental_go
+#cgo nocallback rapidyenc_decode_incremental_go
+#cgo noescape rapidyenc_encode_init
+#cgo nocallback rapidyenc_encode_init
+#cgo noescape rapidyenc_encode_kernel
+#cgo nocallback rapidyenc_encode_kernel
+#cgo noescape rapidyenc_encode
+#cgo nocallback rapidyenc_encode
+#cgo noescape rapidyenc_encode_ex
+#cgo nocallback rapidyenc_encode_ex
+#cgo darwin LDFLAGS: ${SRCDIR}/librapidyenc_darwin.a -lstdc++
+#cgo windows,amd64 LDFLAGS: ${SRCDIR}/librapidyenc_windows_amd64.a -lstdc++
+#cgo linux,amd64 LDFLAGS: ${SRCDIR}/librapidyenc_linux_amd64.a -lstdc++
+#cgo linux,arm64 LDFLAGS: ${SRCDIR}/librapidyenc_linux_arm64.a -lstdc++
+#include "rapidyenc.h"
+*/
+import "C"

--- a/decoder.go
+++ b/decoder.go
@@ -1,10 +1,6 @@
 package rapidyenc
 
 /*
-#cgo darwin LDFLAGS: ${SRCDIR}/librapidyenc_darwin.a -lstdc++
-#cgo windows,amd64 LDFLAGS: ${SRCDIR}/librapidyenc_windows_amd64.a -lstdc++
-#cgo linux,amd64 LDFLAGS: ${SRCDIR}/librapidyenc_linux_amd64.a -lstdc++
-#cgo linux,arm64 LDFLAGS: ${SRCDIR}/librapidyenc_linux_arm64.a -lstdc++
 #include "rapidyenc.h"
 
 // Like `rapidyenc_decode_incremental` but handle the pointer arithmetic

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -12,10 +12,7 @@ import (
 )
 
 func TestDecode(t *testing.T) {
-	space := make([]byte, 800000)
-	for i := range space {
-		space[i] = 0x20
-	}
+	space := bytes.Repeat([]byte(" "), 800000)
 
 	cases := []struct {
 		name string

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -109,6 +109,7 @@ func BenchmarkDecoder(b *testing.B) {
 
 	dec := AcquireDecoder(r)
 
+	b.ResetTimer()
 	for b.Loop() {
 		_, err = io.Copy(io.Discard, dec)
 		require.NoError(b, err)

--- a/encoder.go
+++ b/encoder.go
@@ -91,9 +91,8 @@ func (e *Encoder) Write(p []byte) (n int, err error) {
 	if len(p) > 0 {
 		e.processed += int64(len(p))
 
-		maxLength := maxLength(len(p), e.lineLength)
-		if maxLength > cap(e.buf) {
-			e.buf = make([]byte, maxLength)
+		if grow := maxLength(len(p), e.lineLength) - len(e.buf); grow > 0 {
+			e.buf = append(e.buf, make([]byte, grow)...)
 		}
 
 		buf := e.buf

--- a/encoder.go
+++ b/encoder.go
@@ -5,6 +5,7 @@ package rapidyenc
 */
 import "C"
 import (
+	"errors"
 	"fmt"
 	"golang.org/x/sync/errgroup"
 	"hash"
@@ -173,8 +174,12 @@ func maybeInitEncode() {
 // Encode yEnc encodes the src buffer without adding any =y headers
 //
 // Deprecated: use Encoder as an io.WriteCloser which includes yEnc headers
-func (e *Encoder) Encode(src []byte) []byte {
-	dst := make([]byte, maxLength(len(src), e.lineLength))
+func Encode(src []byte) ([]byte, error) {
+	if len(src) == 0 {
+		return nil, errors.New("empty source")
+	}
+
+	dst := make([]byte, maxLength(len(src), 128))
 
 	length := C.rapidyenc_encode(
 		unsafe.Pointer(&src[0]),
@@ -182,7 +187,7 @@ func (e *Encoder) Encode(src []byte) []byte {
 		C.size_t(len(src)),
 	)
 
-	return dst[:length]
+	return dst[:length], nil
 }
 
 func (e *Encoder) writeHeader() (int, error) {

--- a/encoder.go
+++ b/encoder.go
@@ -1,10 +1,6 @@
 package rapidyenc
 
 /*
-#cgo darwin LDFLAGS: ${SRCDIR}/librapidyenc_darwin.a -lstdc++
-#cgo windows,amd64 LDFLAGS: ${SRCDIR}/librapidyenc_windows_amd64.a -lstdc++
-#cgo linux,amd64 LDFLAGS: ${SRCDIR}/librapidyenc_linux_amd64.a -lstdc++
-#cgo linux,arm64 LDFLAGS: ${SRCDIR}/librapidyenc_linux_arm64.a -lstdc++
 #include "rapidyenc.h"
 */
 import "C"

--- a/encoder.go
+++ b/encoder.go
@@ -31,6 +31,10 @@ type Encoder struct {
 	hashErrs errgroup.Group
 }
 
+// NewEncoder returns a new [Encoder].
+// Writes to the returned writer are yEnc encoded and written to w.
+//
+// It is the caller's responsibility to call Close on the [Encoder] when done.
 func NewEncoder(w io.Writer, m Meta) (e *Encoder) {
 	maybeInitEncode()
 
@@ -44,6 +48,9 @@ func NewEncoder(w io.Writer, m Meta) (e *Encoder) {
 	return
 }
 
+// Reset discards the [Encoder] e's state and makes it equivalent to the
+// result of its original state from [NewEncoder], but writing to w instead.
+// This permits reusing a [Encoder] rather than allocating a new one.
 func (e *Encoder) Reset(w io.Writer, meta Meta) {
 	e.writeMu.Lock()
 	defer e.writeMu.Unlock()
@@ -57,6 +64,8 @@ func (e *Encoder) Reset(w io.Writer, meta Meta) {
 	e.hashErrs = errgroup.Group{}
 }
 
+// Write writes a yEnc encoded form of p to the underlying [io.Writer]. The
+// encoded bytes are not necessarily flushed until the [Encoder] is closed.
 func (e *Encoder) Write(p []byte) (n int, err error) {
 	e.writeMu.Lock()
 	defer e.writeMu.Unlock()

--- a/encoder.go
+++ b/encoder.go
@@ -9,33 +9,153 @@ package rapidyenc
 */
 import "C"
 import (
+	"fmt"
+	"golang.org/x/sync/errgroup"
+	"hash"
+	"hash/crc32"
+	"io"
 	"sync"
 	"unsafe"
 )
 
-// MaxLength returns the maximum possible length of yEnc encoded output given the length of the unencoded data and line length.
-// This function also includes additional padding needed by rapidyenc's implementation.
-func MaxLength(length, lineLength int) int {
-	ret := length * 2 // all characters escaped
-	ret += 2          // allocation for offset and that a newline may occur early
-	ret += 64         // allocation for YMM overflowing
-
-	// add newlines, considering the possibility of all chars escaped
-	if lineLength == 128 {
-		// optimize common case
-		return ret + 2*(length>>6)
-	}
-	return ret + 2*((length*2)/lineLength)
-}
-
 type Encoder struct {
-	LineLength int
+	w        io.Writer
+	m        Meta
+	hWritten bool
+
+	hash       hash.Hash32
+	lineLength int
+	column     int
+	processed  int64
+
+	buf     []byte
+	endByte []byte
+
+	writeMu  sync.Mutex
+	hashErrs errgroup.Group
 }
 
-func NewEncoder() *Encoder {
-	return &Encoder{
-		LineLength: 128,
+func NewEncoder(w io.Writer, m Meta) (e *Encoder) {
+	maybeInitEncode()
+
+	e = new(Encoder)
+	e.lineLength = 128
+	e.hash = crc32.NewIEEE()
+	e.endByte = make([]byte, 0, 1)
+
+	e.Reset(w, m)
+
+	return
+}
+
+func (e *Encoder) Reset(w io.Writer, meta Meta) {
+	e.writeMu.Lock()
+	defer e.writeMu.Unlock()
+
+	e.w = w
+	e.m = meta
+	e.hWritten = false
+	e.hash.Reset()
+	e.endByte = e.endByte[:0]
+	e.processed = 0
+	e.hashErrs = errgroup.Group{}
+}
+
+func (e *Encoder) Write(p []byte) (n int, err error) {
+	e.writeMu.Lock()
+	defer e.writeMu.Unlock()
+
+	n = len(p)
+
+	e.hashErrs.Go(func() error {
+		if _, e := e.hash.Write(p); e != nil {
+			return e
+		}
+		return nil
+	})
+	defer func() {
+		// Other errors take priority
+		if hashErr := e.hashErrs.Wait(); err == nil {
+			err = hashErr
+		}
+	}()
+
+	if _, err := e.writeHeader(); err != nil {
+		return 0, err
 	}
+
+	if len(p) > 0 {
+		e.processed += int64(len(p))
+
+		// Previous Write ended with a space or tab, so we need to include it (without escaping)
+		if len(e.endByte) > 0 {
+			if _, err := e.w.Write(e.endByte); err != nil {
+				return 0, err
+			}
+			e.endByte = e.endByte[:0]
+		}
+
+		maxLength := maxLength(len(p), e.lineLength)
+		if maxLength > cap(e.buf) {
+			e.buf = make([]byte, maxLength)
+		}
+
+		buf := e.buf
+
+		length := C.rapidyenc_encode_ex(
+			C.int(e.lineLength),
+			(*C.int)(unsafe.Pointer(&e.column)),
+			unsafe.Pointer(&p[0]),
+			unsafe.Pointer(&buf[0]),
+			C.size_t(len(p)),
+			C.int(0),
+		)
+
+		if length > 0 {
+			// If the last character is '\t' or ' ' then if this is the last write it will need escaping.
+			// Therefore, save the byte for the next call to Write or Close.
+			if buf[length-1] == '\t' || buf[length-1] == ' ' {
+				e.endByte = append(e.endByte, buf[length-1])
+				buf = buf[:length-1]
+			} else {
+				buf = buf[:length]
+			}
+
+			if len(buf) > 0 {
+				if _, err = e.w.Write(buf); err != nil {
+					return 0, err
+				}
+			}
+		}
+	}
+
+	return
+}
+
+// Close flushes any pending output from the encoder and writes the trailing header.
+// It is an error to call Write after calling Close.
+func (e *Encoder) Close() error {
+	e.writeMu.Lock()
+	defer e.writeMu.Unlock()
+
+	if len(e.endByte) > 0 {
+		if _, err := e.w.Write([]byte{'=', e.endByte[0] + 64}); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintf(e.w, "\r\n=yend size=%d part=%d pcrc32=%08x\r\n", e.m.PartSize, e.m.PartNumber, e.hash.Sum32()); err != nil {
+		return err
+	}
+
+	if e.processed != e.m.PartSize {
+		return fmt.Errorf(
+			"[rapidyenc] encode header has part size %d but actually encoded %d bytes",
+			e.m.PartSize, e.processed,
+		)
+	}
+
+	return nil
 }
 
 var encodeInitOnce sync.Once
@@ -46,10 +166,11 @@ func maybeInitEncode() {
 	})
 }
 
+// Encode yEnc encodes the src buffer without adding any =y headers
+//
+// Deprecated: use Encoder as an io.WriteCloser which includes yEnc headers
 func (e *Encoder) Encode(src []byte) []byte {
-	maybeInitEncode()
-
-	dst := make([]byte, MaxLength(len(src), e.LineLength))
+	dst := make([]byte, maxLength(len(src), e.lineLength))
 
 	length := C.rapidyenc_encode(
 		unsafe.Pointer(&src[0]),
@@ -58,4 +179,32 @@ func (e *Encoder) Encode(src []byte) []byte {
 	)
 
 	return dst[:length]
+}
+
+func (e *Encoder) writeHeader() (int, error) {
+	if e.hWritten {
+		return 0, nil
+	}
+
+	e.hWritten = true
+	return fmt.Fprintf(
+		e.w,
+		"=ybegin part=%d total=%d line=%d size=%d name=%s\r\n=ypart begin=%d end=%d\r\n",
+		e.m.PartNumber, e.m.TotalParts, e.lineLength, e.m.FileSize, e.m.FileName, e.m.Begin(), e.m.End(),
+	)
+}
+
+// maxLength returns the maximum possible length of yEnc encoded output given the length of the unencoded data and line length.
+// maxLength also includes additional padding needed by the rapidyenc implementation.
+func maxLength(length, lineLength int) int {
+	ret := length * 2 // all characters escaped
+	ret += 2          // allocation for offset and that a newline may occur early
+	ret += 64         // allocation for YMM overflowing
+
+	// add newlines, considering the possibility of all chars escaped
+	if lineLength == 128 {
+		// optimize common case
+		return ret + 2*(length>>6)
+	}
+	return ret + 2*((length*2)/lineLength)
 }

--- a/encoder.go
+++ b/encoder.go
@@ -107,14 +107,16 @@ func (e *Encoder) Write(p []byte) (n int, err error) {
 
 		buf := e.buf
 
+		colTmp := C.int(e.column)
 		length := C.rapidyenc_encode_ex(
 			C.int(e.lineLength),
-			(*C.int)(unsafe.Pointer(&e.column)),
+			(*C.int)(unsafe.Pointer(&colTmp)),
 			unsafe.Pointer(&p[0]),
 			unsafe.Pointer(&buf[0]),
 			C.size_t(len(p)),
 			C.int(0),
 		)
+		e.column = int(colTmp)
 
 		if length > 0 {
 			// If the last character is '\t' or ' ' then if this is the last write it will need escaping.

--- a/encoder.go
+++ b/encoder.go
@@ -80,16 +80,16 @@ func (e *Encoder) Write(p []byte) (n int, err error) {
 		return 0, err
 	}
 
+	// Previous Write ended with a space or tab, so we need to include it (without escaping)
+	if len(e.endByte) > 0 {
+		if _, err := e.w.Write(e.endByte); err != nil {
+			return 0, err
+		}
+		e.endByte = e.endByte[:0]
+	}
+
 	if len(p) > 0 {
 		e.processed += int64(len(p))
-
-		// Previous Write ended with a space or tab, so we need to include it (without escaping)
-		if len(e.endByte) > 0 {
-			if _, err := e.w.Write(e.endByte); err != nil {
-				return 0, err
-			}
-			e.endByte = e.endByte[:0]
-		}
 
 		maxLength := maxLength(len(p), e.lineLength)
 		if maxLength > cap(e.buf) {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -71,6 +71,7 @@ func BenchmarkEncoder(b *testing.B) {
 
 	enc := NewEncoder(io.Discard, meta)
 
+	b.ResetTimer()
 	for b.Loop() {
 		_, err = io.Copy(enc, r)
 		require.NoError(b, err)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,28 +1,83 @@
 package rapidyenc
 
 import (
+	"bytes"
+	"crypto/rand"
 	"github.com/stretchr/testify/require"
+	"hash/crc32"
+	"io"
 	"testing"
 )
 
 type encoderCase struct {
 	name     string
-	input    string
-	expected string
+	input    []byte
+	expected []byte
 }
 
 func TestEncoderSimple(t *testing.T) {
 	cases := []encoderCase{
-		{"NUL", "\x00", "\x2a"},
-		{"SPACE", "\x20", "\x4a"},
+		{"NUL", []byte("\x00"), []byte("\x2a")},
+		{"SPACE", []byte("\x20"), []byte("\x4a")},
+		{"ESCAPE", []byte("\xF6"), []byte("\x3D\x60")},                // Ends with <space> so must be escaped
+		{"ESCAPE_NOT_FIRST", []byte("H\xF6"), []byte("\x72\x3D\x60")}, // Ends with <space> and not the first column, so must be escaped
+		{"Hello World", []byte("Hello World"), []byte("\x72\x8F\x96\x96\x99\x4A\x81\x99\x9C\x96\x8E")},
 	}
-
-	encoder := NewEncoder()
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			encoded := encoder.Encode([]byte(tc.input))
-			require.Equal(t, []byte(tc.expected), encoded)
+			input := bytes.NewReader(tc.input)
+
+			encoded := new(bytes.Buffer)
+			w := NewEncoder(encoded, Meta{
+				FileName: "filename",
+				FileSize: input.Size(),
+				PartSize: input.Size(),
+			})
+			_, err := io.Copy(w, input)
+			require.NoError(t, err)
+			err = w.Close()
+			require.NoError(t, err)
+
+			// Check contains the expected encoded value
+			expected := append([]byte("\r\n"), append(tc.expected, []byte("\r\n")[:]...)...)
+			require.True(t, bytes.Contains(encoded.Bytes(), expected))
+
+			// Check that we can decode it back again
+			decoded := new(bytes.Buffer)
+			r := NewDecoder(encoded)
+			_, err = io.Copy(decoded, r)
+			require.NoError(t, err)
+			require.Equal(t, tc.input, decoded.Bytes())
+			require.Equal(t, int64(len(tc.input)), r.Meta.PartSize)
+			require.Equal(t, crc32.ChecksumIEEE(tc.input), r.Meta.Hash)
+			require.Equal(t, int64(len(tc.input)), r.Meta.End())
 		})
+	}
+}
+
+func BenchmarkEncoder(b *testing.B) {
+	raw := make([]byte, 1024*1024)
+	_, err := rand.Read(raw)
+	require.NoError(b, err)
+
+	r := bytes.NewReader(raw)
+
+	meta := Meta{
+		FileName: "filename",
+		FileSize: int64(len(raw)),
+		PartSize: int64(len(raw)),
+	}
+
+	enc := NewEncoder(io.Discard, meta)
+
+	for b.Loop() {
+		_, err = io.Copy(enc, r)
+		require.NoError(b, err)
+		err = enc.Close()
+		require.NoError(b, err)
+		_, err = r.Seek(0, io.SeekStart)
+		require.NoError(b, err)
+		enc.Reset(io.Discard, meta)
 	}
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -67,9 +67,11 @@ func BenchmarkEncoder(b *testing.B) {
 	r := bytes.NewReader(raw)
 
 	meta := Meta{
-		FileName: "filename",
-		FileSize: int64(len(raw)),
-		PartSize: int64(len(raw)),
+		FileName:   "filename",
+		FileSize:   int64(len(raw)),
+		PartSize:   int64(len(raw)),
+		PartNumber: 1,
+		TotalParts: 1,
 	}
 
 	enc, err := NewEncoder(io.Discard, meta)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -29,12 +29,15 @@ func TestEncoderSimple(t *testing.T) {
 			input := bytes.NewReader(tc.input)
 
 			encoded := new(bytes.Buffer)
-			w := NewEncoder(encoded, Meta{
-				FileName: "filename",
-				FileSize: input.Size(),
-				PartSize: input.Size(),
+			w, err := NewEncoder(encoded, Meta{
+				FileName:   "filename",
+				FileSize:   input.Size(),
+				PartSize:   input.Size(),
+				PartNumber: 1,
+				TotalParts: 1,
 			})
-			_, err := io.Copy(w, input)
+			require.NoError(t, err)
+			_, err = io.Copy(w, input)
 			require.NoError(t, err)
 			err = w.Close()
 			require.NoError(t, err)
@@ -69,7 +72,8 @@ func BenchmarkEncoder(b *testing.B) {
 		PartSize: int64(len(raw)),
 	}
 
-	enc := NewEncoder(io.Discard, meta)
+	enc, err := NewEncoder(io.Discard, meta)
+	require.NoError(b, err)
 
 	b.ResetTimer()
 	for b.Loop() {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/sync v0.15.0
 	golang.org/x/text v0.26.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
 golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/meta.go
+++ b/meta.go
@@ -1,0 +1,25 @@
+package rapidyenc
+
+type Meta struct {
+	FileName   string
+	FileSize   int64 // Total size of the file
+	PartNumber int64
+	TotalParts int64
+	Offset     int64 // Offset of the part within the file relative to the start, like io.Seeker or io.WriterAt
+	PartSize   int64 // Size of the unencoded data
+}
+
+// Begin is the "=ypart begin" value calculated from the Offset
+func (m Meta) Begin() int64 {
+	return m.Offset + 1
+}
+
+// End is the "=ypart end" value calculated from the Offset and PartSize
+func (m Meta) End() int64 {
+	return m.Offset + m.PartSize
+}
+
+type DecodedMeta struct {
+	Meta
+	Hash uint32 // CRC32 hash of the decoded data
+}

--- a/meta.go
+++ b/meta.go
@@ -1,5 +1,7 @@
 package rapidyenc
 
+import "errors"
+
 type Meta struct {
 	FileName   string
 	FileSize   int64 // Total size of the file
@@ -22,4 +24,36 @@ func (m Meta) End() int64 {
 type DecodedMeta struct {
 	Meta
 	Hash uint32 // CRC32 hash of the decoded data
+}
+
+var (
+	errFileNameEmpty = errors.New("file name is empty")
+	errFileSize      = errors.New("file size is less than or equal to zero")
+	errPartNumber    = errors.New("part number is less than or equal to zero")
+	errTotalParts    = errors.New("total tarts is less than part number")
+	errOffset        = errors.New("offset is less than zero")
+	errPartSize      = errors.New("part size is less than or equal to zero")
+)
+
+func (m Meta) validate() error {
+	if len(m.FileName) == 0 {
+		return errFileNameEmpty
+	}
+	if m.FileSize <= 0 {
+		return errFileSize
+	}
+	if m.PartNumber <= 0 {
+		return errPartNumber
+	}
+	if m.TotalParts < m.PartNumber {
+		return errTotalParts
+	}
+	if m.Offset < 0 {
+		return errOffset
+	}
+	if m.PartSize <= 0 {
+		return errPartSize
+	}
+
+	return nil
 }

--- a/meta_test.go
+++ b/meta_test.go
@@ -1,0 +1,31 @@
+package rapidyenc
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMetaValidation(t *testing.T) {
+	m := Meta{}
+
+	require.ErrorIs(t, m.validate(), errFileNameEmpty)
+	m.FileName = "foobar"
+
+	require.ErrorIs(t, m.validate(), errFileSize)
+	m.FileSize = 1000
+
+	require.ErrorIs(t, m.validate(), errPartNumber)
+	m.PartNumber = 1
+
+	require.ErrorIs(t, m.validate(), errTotalParts)
+	m.TotalParts = 10
+
+	m.Offset = -1
+	require.ErrorIs(t, m.validate(), errOffset)
+	m.Offset = 0
+
+	require.ErrorIs(t, m.validate(), errPartSize)
+	m.PartSize = 100
+
+	require.NoError(t, m.validate())
+}

--- a/platform.go
+++ b/platform.go
@@ -1,10 +1,6 @@
 package rapidyenc
 
 /*
-#cgo darwin LDFLAGS: ${SRCDIR}/librapidyenc_darwin.a -lstdc++
-#cgo windows,amd64 LDFLAGS: ${SRCDIR}/librapidyenc_windows_amd64.a -lstdc++
-#cgo linux,amd64 LDFLAGS: ${SRCDIR}/librapidyenc_linux_amd64.a -lstdc++
-#cgo linux,arm64 LDFLAGS: ${SRCDIR}/librapidyenc_linux_arm64.a -lstdc++
 #include "rapidyenc.h"
 */
 import "C"


### PR DESCRIPTION
I've introduced some breaking changes to the decoder unfortunately, but generally this PR is intended to make the package a little nicer to work with.

## Decoder

- `AcquireDecoder()` => `AcquireDecoder(r io.Reader)`
- `Reset()` => `Reset(r io.Reader)` for reusing an existing decoder, but I suppose you could just Acquire/Release instead
- Removed `SetReader(reader io.Reader)` as it's replaced with `Reset(r io.Reader)`
- `Meta()` replaced with `Meta` field - which is shares fields used by the encoder
  - `Name` => `FileName`
  - `Size` => `FileSize`
  - `Begin` => `Begin()`
  - `End` => `End()`
  - Added `Offset` and `PartSize`, which I think are more useful for reading/writing files and consistent with what will be needed elsewhere
  - Also added `PartNumber` and `TotalParts` but they're primarily for the encoder

## Encoder

`Encoder` implements `io.WriteCloser`, you must call `Close` after you've finished writing.

- `NewEncoder()` => `NewEncoder(w io.Writer, m Meta)`
  - All the Meta struct fields should be provided `FileName`, `FileSize`, `PartNumber`, `TotalParts`, `Offset`, and `PartSize`
  - `Write` and `Close` will use the Meta provided to create the `=ybegin`, `=ypart`, and `=yend` headers
- `MaxLength` is no longer public
- `func (e *Encoder) Encode(src []byte) []byte` => `func Encode(src []byte) ([]byte, error)`
  - Removed from Encoder struct because it only ever supported line lengths of 128 anyway
  - The method is marked deprecated and will probably be removed if I tag a v1 release

## Just a little note on the future of this package

- Before a v1 release I may remove `AcquireDecoder` and `ReleaseDecoder` thus leaving it to the consuming application to decide if they want to pool decoders.
- I'd like to look into using [mmcloughlin/avo](https://github.com/mmcloughlin/avo) to remove the CGO requirement and port the rapidyenc implementations, but at the moment the assembly required is rather beyond me. It would likely only be x86 since avo doesn't support Arm yet.

@javi11 perhaps you'd be willing to try out the new encoder methods?